### PR TITLE
fix(artisttype.js): prevent undefined value in artist type selection

### DIFF
--- a/screens/ArtistType.js
+++ b/screens/ArtistType.js
@@ -63,7 +63,7 @@ const ArtistType = () => {
               key={type.id}
               onPress={() =>
                 handleSelection(
-                  `${type.name}${type.secondaryName && type.secondaryName}`
+                  `${type.name}${type.secondaryName ? type.secondaryName : ''}`
                 )
               }
             >


### PR DESCRIPTION
 Fixed the issue where artist type was being passed as "typeNameundefined" when secondaryName was not provided.

